### PR TITLE
feat: use git-lfs for images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text=auto eol=lf
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text

--- a/src/generated-files/gitattributes.js
+++ b/src/generated-files/gitattributes.js
@@ -2,5 +2,7 @@ import { endent } from '@dword-design/functions'
 
 export default endent`
   * text=auto eol=lf
+  *.jpg filter=lfs diff=lfs merge=lfs -text
+  *.png filter=lfs diff=lfs merge=lfs -text
 
 `


### PR DESCRIPTION
If your project should use lfs for images, you have to remove and re-add them to the repo.

BREAKING CHANGE: use git-lfs for images